### PR TITLE
Modify unselectDeck method to fix bug

### DIFF
--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -197,7 +197,7 @@ public class ModelManager implements Model {
 
     @Override
     public void unselectDeck() {
-        this.selectedDeck = null;
+        this.selectedDeck = Optional.empty();
         updateFilteredCardList(PREDICATE_SHOW_ALL_CARDS);
     }
 


### PR DESCRIPTION
Fix bug in unselectDeck behavior.

How to replicate:
1. Create a deck
2. Select the deck
3. Unselect the deck
4. Exit throught the command line

Reason:
unselectDeck method set `selectedDeck` to `null` instead of `Optional.empty()`

