### PR TITLE
Modify Optional usage

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -45,20 +45,17 @@ public class LogicManager implements Logic {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
 
         Command command;
+
         Optional<Deck> selectedDeck = this.model.getSelectedDeck();
         Optional<Review> currReview = this.model.getReview();
 
-//        if (currReview != null) {
-//            command = masterDeckParser.parseCommandWhenReviewing(commandText);
-//        } else if (selectedDeck.isPresent()) {
-//            command = masterDeckParser.parseCommandWhenDeckSelected(commandText);
-//        } else {
-//            command = masterDeckParser.parseCommandWhenDeckNotSelected(commandText);
-//        }
-
-        currReview.
-
-        masterDeckParser.parseCommand(commandText, selectedDeck.isPresent(), currReview.isPresent());
+        if (currReview.isPresent()) {
+            command = masterDeckParser.parseCommandWhenReviewing(commandText);
+        } else if (selectedDeck.isPresent()) {
+            command = masterDeckParser.parseCommandWhenDeckSelected(commandText);
+        } else {
+            command = masterDeckParser.parseCommandWhenDeckNotSelected(commandText);
+        }
 
         CommandResult commandResult = command.execute(model);
 

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -44,20 +44,23 @@ public class LogicManager implements Logic {
     public CommandResult execute(String commandText) throws CommandException, ParseException {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
 
-        CommandResult commandResult;
         Command command;
         Optional<Deck> selectedDeck = this.model.getSelectedDeck();
-        Review currReview = this.model.getReview();
+        Optional<Review> currReview = this.model.getReview();
 
-        if (currReview != null) {
-            command = masterDeckParser.parseCommandWhenReviewing(commandText);
-        } else if (selectedDeck.isPresent()) {
-            command = masterDeckParser.parseCommandWhenDeckSelected(commandText);
-        } else {
-            command = masterDeckParser.parseCommandWhenDeckNotSelected(commandText);
-        }
+//        if (currReview != null) {
+//            command = masterDeckParser.parseCommandWhenReviewing(commandText);
+//        } else if (selectedDeck.isPresent()) {
+//            command = masterDeckParser.parseCommandWhenDeckSelected(commandText);
+//        } else {
+//            command = masterDeckParser.parseCommandWhenDeckNotSelected(commandText);
+//        }
 
-        commandResult = command.execute(model);
+        currReview.
+
+        masterDeckParser.parseCommand(commandText, selectedDeck.isPresent(), currReview.isPresent());
+
+        CommandResult commandResult = command.execute(model);
 
         try {
             storage.saveAddressBook(model.getMasterDeck());

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -52,10 +52,11 @@ public class LogicManager implements Logic {
         if (currReview != null) {
             command = masterDeckParser.parseCommandWhenReviewing(commandText);
         } else if (selectedDeck.isPresent()) {
-            command = masterDeckParser.parseCommandWhenDeckSelected(commandText, selectedDeck);
+            command = masterDeckParser.parseCommandWhenDeckSelected(commandText);
         } else {
             command = masterDeckParser.parseCommandWhenDeckNotSelected(commandText);
         }
+
         commandResult = command.execute(model);
 
         try {

--- a/src/main/java/seedu/address/logic/commands/FlipCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FlipCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import seedu.address.model.Model;
+import seedu.address.model.review.Review;
 
 /**
  * Flips the current flashcard under review to show its answer to the user.
@@ -17,7 +18,7 @@ public class FlipCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.getReview().flipCard();
+        model.getReview().ifPresent(Review::flipCard);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/FlipCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FlipCommand.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import seedu.address.model.Model;
-import seedu.address.model.review.Review;
 
 /**
  * Flips the current flashcard under review to show its answer to the user.
@@ -18,7 +17,7 @@ public class FlipCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.getReview().ifPresent(Review::flipCard);
+        model.flipCard(); // Todo: any possible exception here?
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/MasterDeckParser.java
+++ b/src/main/java/seedu/address/logic/parser/MasterDeckParser.java
@@ -35,6 +35,10 @@ public class MasterDeckParser {
      */
     private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
 
+
+    public Command parseCommand(String userInput, is)
+
+
     /**
      * Parses user input into command for execution when no deck is selected.
      *

--- a/src/main/java/seedu/address/logic/parser/MasterDeckParser.java
+++ b/src/main/java/seedu/address/logic/parser/MasterDeckParser.java
@@ -94,7 +94,7 @@ public class MasterDeckParser {
      * @return the command based on the user input
      * @throws ParseException if the user input does not conform the expected format
      */
-    public Command parseCommandWhenDeckSelected(String userInput, Optional<Deck> selectedDeck) throws ParseException {
+    public Command parseCommandWhenDeckSelected(String userInput) throws ParseException {
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
         if (!matcher.matches()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/address/logic/parser/MasterDeckParser.java
+++ b/src/main/java/seedu/address/logic/parser/MasterDeckParser.java
@@ -35,10 +35,6 @@ public class MasterDeckParser {
      */
     private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
 
-
-    public Command parseCommand(String userInput, is)
-
-
     /**
      * Parses user input into command for execution when no deck is selected.
      *

--- a/src/main/java/seedu/address/logic/parser/MasterDeckParser.java
+++ b/src/main/java/seedu/address/logic/parser/MasterDeckParser.java
@@ -3,7 +3,6 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 
-import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -23,7 +22,6 @@ import seedu.address.logic.commands.ReviewCommand;
 import seedu.address.logic.commands.SelectDeckCommand;
 import seedu.address.logic.commands.UnselectDeckCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.deck.Deck;
 
 /**
  * Parses user input.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -122,4 +122,6 @@ public interface Model {
     void endReview();
 
     String getReviewDeckName();
+
+    void flipCard();
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -117,7 +117,7 @@ public interface Model {
 
     void reviewDeck(Index idx);
 
-    Review getReview();
+    Optional<Review> getReview();
 
     void endReview();
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -27,11 +27,9 @@ public class ModelManager implements Model {
 
     private MasterDeck masterDeck;
     private final UserPrefs userPrefs;
-
     private FilteredList<Deck> filteredDecks;
     private Optional<Deck> selectedDeck = Optional.empty();
     private Optional<Review> currReview = Optional.empty();
-
     private FilteredList<Card> filteredCards;
 
     /**
@@ -197,7 +195,7 @@ public class ModelManager implements Model {
 
     @Override
     public void unselectDeck() {
-        this.selectedDeck = null;
+        this.selectedDeck = Optional.empty();
         updateFilteredCardList(PREDICATE_SHOW_ALL_CARDS);
     }
 
@@ -225,13 +223,14 @@ public class ModelManager implements Model {
     };
 
     @Override
-    public Review getReview() {
-        return currReview.orElse(null);
+    public Optional<Review> getReview() {
+        return currReview;
     };
 
     @Override
     public void endReview() {
         currReview = Optional.empty();
+        // Todo: set predicate to showing all cards again?
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -25,12 +25,12 @@ import seedu.address.model.review.Review;
 public class ModelManager implements Model {
     private static final Logger logger = LogsCenter.getLogger(ModelManager.class);
 
-    private MasterDeck masterDeck;
+    private final MasterDeck masterDeck;
     private final UserPrefs userPrefs;
-    private FilteredList<Deck> filteredDecks;
-    private Optional<Deck> selectedDeck = Optional.empty();
-    private Optional<Review> currReview = Optional.empty();
-    private FilteredList<Card> filteredCards;
+    private final FilteredList<Deck> filteredDecks;
+    private final FilteredList<Card> filteredCards;
+    private Deck selectedDeck;
+    private Review currReview;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -50,9 +50,7 @@ public class ModelManager implements Model {
         this(new MasterDeck(), new UserPrefs());
     }
 
-
-
-    //=========== UserPrefs ==================================================================================
+    /* UserPrefs */
 
     @Override
     public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
@@ -87,7 +85,7 @@ public class ModelManager implements Model {
         userPrefs.setAddressBookFilePath(masterDeckFilePath);
     }
 
-    //=========== PowerDeck ================================================================================
+    /* MasterDeck Operations */
 
     @Override
     public void setMasterDeck(ReadOnlyMasterDeck deck) {
@@ -98,6 +96,8 @@ public class ModelManager implements Model {
     public ReadOnlyMasterDeck getMasterDeck() {
         return masterDeck;
     }
+
+    /* PowerCard Operations */
 
     @Override
     public boolean hasCard(Card card) {
@@ -118,11 +118,10 @@ public class ModelManager implements Model {
     @Override
     public void setCard(Card target, Card editedCard) {
         requireAllNonNull(target, editedCard);
-
         masterDeck.setCard(target, editedCard);
     }
 
-    //=========== Filtered Card/Deck List Accessors =============================================================
+    /* Filtered Card/Deck List Accessors */
 
     /**
      * Returns an unmodifiable view of the list of {@code Card} backed by the internal list of
@@ -163,7 +162,8 @@ public class ModelManager implements Model {
     }
 
 
-    /* NEWLY ADDED COMMANDS TO SUPPORT DECKS */
+    /* PowerDeck Operations */
+
     @Override
     public void updateFilteredDeckList(Predicate<Deck> predicate) {
         requireNonNull(predicate);
@@ -190,28 +190,32 @@ public class ModelManager implements Model {
     @Override
     public void selectDeck(Index deckIndex) {
         int zeroBasesIdx = deckIndex.getZeroBased();
-        selectedDeck = Optional.of(filteredDecks.get(zeroBasesIdx));
+        selectedDeck = filteredDecks.get(zeroBasesIdx);
     }
 
     @Override
     public void unselectDeck() {
-        this.selectedDeck = Optional.empty();
+        this.selectedDeck = null;
         updateFilteredCardList(PREDICATE_SHOW_ALL_CARDS);
     }
 
     @Override
     public Optional<Deck> getSelectedDeck() {
-        return selectedDeck;
+        return Optional.ofNullable(selectedDeck);
     }
 
     @Override
     public String getSelectedDeckName() {
-        return selectedDeck.get().getDeckName();
+        return Optional.ofNullable(selectedDeck)
+                .map(Deck::getDeckName)
+                .orElse("None");
     }
+
+    /* Review Operations */
 
     /**
      * Starts a new review session based on deckIndex selected
-     * @param deckIndex
+     * @param deckIndex Index of the deck
      */
     public void reviewDeck(Index deckIndex) {
         int zeroBasesIdx = deckIndex.getZeroBased();
@@ -219,23 +223,25 @@ public class ModelManager implements Model {
         List<Card> cardList = new FilteredList<>(
                 masterDeck.getCardList(), new CardInDeckPredicate(deckToReview)
         );
-        currReview = Optional.of(new Review(deckToReview, cardList));
-    };
+        currReview = new Review(deckToReview, cardList);
+    }
 
     @Override
     public Optional<Review> getReview() {
-        return currReview;
+        return Optional.ofNullable(currReview);
     };
 
     @Override
     public void endReview() {
-        currReview = Optional.empty();
+        currReview = null;
         // Todo: set predicate to showing all cards again?
     }
 
     @Override
     public String getReviewDeckName() {
-        return currReview.map(rev -> rev.getDeckName()).orElse(null);
+        return Optional.ofNullable(currReview)
+                .map(Review::getDeckName)
+                .orElse("None");
     }
 
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -50,7 +50,7 @@ public class ModelManager implements Model {
         this(new MasterDeck(), new UserPrefs());
     }
 
-    /* UserPrefs */
+    /* ==================================== UserPrefs ==================================== */
 
     @Override
     public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
@@ -121,7 +121,7 @@ public class ModelManager implements Model {
         masterDeck.setCard(target, editedCard);
     }
 
-    /* Filtered Card/Deck List Accessors */
+    /* ==================================== Filtered Card/Deck List Accessors ==================================== */
 
     /**
      * Returns an unmodifiable view of the list of {@code Card} backed by the internal list of
@@ -162,7 +162,7 @@ public class ModelManager implements Model {
     }
 
 
-    /* PowerDeck Operations */
+    /* ==================================== PowerDeck Operations ==================================== */
 
     @Override
     public void updateFilteredDeckList(Predicate<Deck> predicate) {
@@ -211,7 +211,7 @@ public class ModelManager implements Model {
                 .orElse("None");
     }
 
-    /* Review Operations */
+    /* ==================================== Review Operations ==================================== */
 
     /**
      * Starts a new review session based on deckIndex selected
@@ -234,7 +234,6 @@ public class ModelManager implements Model {
     @Override
     public void endReview() {
         currReview = null;
-        // Todo: set predicate to showing all cards again?
     }
 
     @Override
@@ -244,4 +243,7 @@ public class ModelManager implements Model {
                 .orElse("None");
     }
 
+    public void flipCard() {
+        Optional.ofNullable(currReview).ifPresent(Review::flipCard);
+    }
 }

--- a/src/main/java/seedu/address/model/review/Review.java
+++ b/src/main/java/seedu/address/model/review/Review.java
@@ -43,7 +43,7 @@ public class Review {
         return currScore;
     }
 
-    public void incrementCurrentScore() {
+    public void incrementCurrScore() {
         currScore++;
     }
 

--- a/src/main/java/seedu/address/model/review/Review.java
+++ b/src/main/java/seedu/address/model/review/Review.java
@@ -92,6 +92,7 @@ public class Review {
     /**
      * Returns the string to be displayed of the current card
      * depending on if the card is flipped
+     *
      * @return Question or (Question and Answer) of current card.
      */
     public String displayOnCard() {

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -202,7 +202,8 @@ public class AddCommandTest {
         public String getSelectedDeckName() {
             throw new AssertionError("This method should not be called.");
         }
-        public Review getReview() {
+
+        public Optional<Review> getReview() {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -222,6 +222,10 @@ public class AddCommandTest {
             throw new AssertionError("This method should not be called.");
         }
 
+        @Override
+        public void flipCard() {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**


### PR DESCRIPTION
Modify Optional occurences in ModelManager to be more appropriate for its intended use.

According to this [article](https://www.oracle.com/technical-resources/articles/java/java8-optional.html), if a method returns an object that may or may not be present, you can use Optional to indicate the possible absence of the value. This makes it clear to the calling code that they should handle the case where the value is absent.

From this use case, we should only instantiate an Optional instance when we return an object that may or may not be null, and not when we instantiate that object. 

For example, `selectDeck` field can be null or a Deck, but the method `getSelectedDeck()` should return an Optional<Deck> instance so that we can handle explicitly the null values.

Other changes:
- Fix bug at #88
- Remove unused field in ParseCommandWhenDeckSelected