### PR TITLE
Modify Command classes to follow Law Of Demeter

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -10,7 +10,6 @@ import java.util.Optional;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.card.Card;
-import seedu.address.model.card.CardInDeckPredicate;
 import seedu.address.model.deck.Deck;
 
 /**
@@ -52,7 +51,6 @@ public class AddCommand extends Command {
         }
         toAdd.setDeck(selectedDeck);
         model.addCard(toAdd);
-        model.updateFilteredCardList(new CardInDeckPredicate(model.getSelectedDeck().get()));
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
     }
 

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -8,11 +8,10 @@ import seedu.address.model.Model;
 /**
  * Clears the address book.
  */
-public class ClearCommand extends Command {
+public class ClearCommand extends Command { //todo: this command is dangerous and should warn users in the future
 
     public static final String COMMAND_WORD = "clear";
     public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
-
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/address/logic/commands/SelectDeckCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SelectDeckCommand.java
@@ -7,7 +7,6 @@ import java.util.List;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.card.CardInDeckPredicate;
 import seedu.address.model.deck.Deck;
 
 

--- a/src/main/java/seedu/address/logic/commands/SelectDeckCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SelectDeckCommand.java
@@ -45,7 +45,6 @@ public class SelectDeckCommand extends Command {
         }
 
         model.selectDeck(deckIndex);
-        model.updateFilteredCardList(new CardInDeckPredicate(model.getSelectedDeck().get()));
         return new CommandResult(String.format(MESSAGE_SUCCESS, model.getSelectedDeckName()));
     }
 

--- a/src/main/java/seedu/address/logic/parser/MasterDeckParser.java
+++ b/src/main/java/seedu/address/logic/parser/MasterDeckParser.java
@@ -111,6 +111,9 @@ public class MasterDeckParser {
         case ReviewCommand.COMMAND_WORD:
             return new ReviewCommandParser().parse(arguments);
 
+        case ExitCommand.COMMAND_WORD:
+            return new ExitCommand();
+
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
         }
@@ -138,6 +141,9 @@ public class MasterDeckParser {
 
         case FlipCommand.COMMAND_WORD:
             return new FlipCommand();
+
+        case ExitCommand.COMMAND_WORD:
+            return new ExitCommand();
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -113,6 +113,7 @@ public class ModelManager implements Model {
     @Override
     public void addCard(Card card) {
         masterDeck.addCard(card);
+        updateFilteredCardList(new CardInDeckPredicate(selectedDeck));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -191,6 +191,7 @@ public class ModelManager implements Model {
     public void selectDeck(Index deckIndex) {
         int zeroBasesIdx = deckIndex.getZeroBased();
         selectedDeck = filteredDecks.get(zeroBasesIdx);
+        updateFilteredCardList(new CardInDeckPredicate(selectedDeck));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -113,7 +113,11 @@ public class ModelManager implements Model {
     @Override
     public void addCard(Card card) {
         masterDeck.addCard(card);
-        updateFilteredCardList(new CardInDeckPredicate(selectedDeck));
+
+        // only update filteredCardList if a deck is selected
+        Optional.ofNullable(selectedDeck)
+                .map(CardInDeckPredicate::new)
+                .ifPresent(this::updateFilteredCardList);
     }
 
     @Override
@@ -192,6 +196,8 @@ public class ModelManager implements Model {
     public void selectDeck(Index deckIndex) {
         int zeroBasesIdx = deckIndex.getZeroBased();
         selectedDeck = filteredDecks.get(zeroBasesIdx);
+
+        assert selectedDeck != null : "selectedDeck cannot be null here";
         updateFilteredCardList(new CardInDeckPredicate(selectedDeck));
     }
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -112,12 +112,7 @@ public class ModelManager implements Model {
 
     @Override
     public void addCard(Card card) {
-        masterDeck.addCard(card);
-
-        // only update filteredCardList if a deck is selected
-        Optional.ofNullable(selectedDeck)
-                .map(CardInDeckPredicate::new)
-                .ifPresent(this::updateFilteredCardList);
+        masterDeck.addCard(card); // Todo: setDeck of card to selectedDeck here
     }
 
     @Override


### PR DESCRIPTION
Currently some Command classes have to retrieve the `selectedDeck` from ModelManger then interact with it. I propose moving the interactions with SelectedDeck to ModelManager itself to reduce coupling in the Commands, thus following Law Of Demeter.
