### PR TITLE
Remove deck prefix and add deleteDeck

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddDeckCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddDeckCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DECK;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -16,9 +15,9 @@ public class AddDeckCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Creates a new deck "
             + "Parameters: "
-            + PREFIX_DECK + "DECK NAME\n"
+            + "DECK NAME\n"
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_DECK + "LAK1201";
+            + "LAK1201";
 
     public static final String MESSAGE_SUCCESS = "New deck created: %1$s";
     public static final String MESSAGE_DUPLICATE_DECK = "This deck already exists in the deck list";

--- a/src/main/java/seedu/address/logic/commands/DeleteDeckCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteDeckCommand.java
@@ -37,10 +37,12 @@ public class DeleteDeckCommand extends Command {
         List<Deck> deckList = model.getFilteredDeckList();
 
         if (deckIndex.getZeroBased() >= deckList.size()) {
-           throw new CommandException(Messages.MESSAGE_INVALID_CARD_DISPLAYED_INDEX);
+           throw new CommandException(Messages.MESSAGE_INVALID_DECK_DISPLAYED_INDEX);
         }
 
         Deck targetDeck = deckList.get(deckIndex.getZeroBased());
+
+        model.removeDeck(targetDeck);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, targetDeck.getDeckName()));
     }

--- a/src/main/java/seedu/address/logic/commands/DeleteDeckCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteDeckCommand.java
@@ -10,6 +10,9 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.deck.Deck;
 
+/**
+ * Deletes a deck identified using its displayed index from the deck list.
+ */
 public class DeleteDeckCommand extends Command {
 
     public static final String COMMAND_WORD = "deleteDeck";
@@ -37,7 +40,7 @@ public class DeleteDeckCommand extends Command {
         List<Deck> deckList = model.getFilteredDeckList();
 
         if (deckIndex.getZeroBased() >= deckList.size()) {
-           throw new CommandException(Messages.MESSAGE_INVALID_DECK_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MESSAGE_INVALID_DECK_DISPLAYED_INDEX);
         }
 
         Deck targetDeck = deckList.get(deckIndex.getZeroBased());

--- a/src/main/java/seedu/address/logic/commands/DeleteDeckCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteDeckCommand.java
@@ -1,0 +1,55 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.deck.Deck;
+
+public class DeleteDeckCommand extends Command {
+
+    public static final String COMMAND_WORD = "deleteDeck";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Select a deck to delete "
+            + "by the index number used in the displayed deck list.\n"
+            + "Parameter: INDEX (must be a positive integer).\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_SUCCESS = "Deck deleted: %1$s"; // %1$s is the first argument in format
+    public static final String MESSAGE_INVALID_DECK_DISPLAYED_INDEX = "Deck index provided is invalid";
+    private final Index deckIndex;
+
+    /**
+     * Creates a DeleteDeckCommand to delete the specified {@code Deck}
+     */
+    public DeleteDeckCommand(Index idx) {
+        requireNonNull(idx);
+        this.deckIndex = idx;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        List<Deck> deckList = model.getFilteredDeckList();
+
+        if (deckIndex.getZeroBased() >= deckList.size()) {
+           throw new CommandException(Messages.MESSAGE_INVALID_CARD_DISPLAYED_INDEX);
+        }
+
+        Deck targetDeck = deckList.get(deckIndex.getZeroBased());
+
+        return new CommandResult(String.format(MESSAGE_SUCCESS, targetDeck.getDeckName()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof DeleteDeckCommand // instanceof handles nulls
+                && deckIndex.equals(((DeleteDeckCommand) other).deckIndex));
+    }
+
+}

--- a/src/main/java/seedu/address/logic/commands/EditDeckCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditDeckCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DECK;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_DECKS;
 
 import java.util.List;
@@ -24,9 +23,9 @@ public class EditDeckCommand extends Command {
             + "by the index number used in the displayed deck list. "
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + PREFIX_DECK + "[DECK NAME]...\n"
+            + "[DECK NAME]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_DECK + "LAC1201";
+            + "LAC1201";
 
     public static final String MESSAGE_EDIT_DECK_SUCCESS = "Edited Deck: %1$s";
     public static final String MESSAGE_DUPLICATE_DECK = "This deck name already exists.";
@@ -36,7 +35,7 @@ public class EditDeckCommand extends Command {
 
     /**
      * @param index      of the deck to edit
-     * @param editedDeck
+     * @param editedDeck edited deck of new name
      */
     public EditDeckCommand(Index index, Deck editedDeck) {
         requireNonNull(index);

--- a/src/main/java/seedu/address/logic/parser/AddDeckCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddDeckCommandParser.java
@@ -20,8 +20,6 @@ public class AddDeckCommandParser implements Parser<AddDeckCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public AddDeckCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args);
 
         Deck deck = ParserUtil.parseDeck(args);
 

--- a/src/main/java/seedu/address/logic/parser/AddDeckCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddDeckCommandParser.java
@@ -1,10 +1,5 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-//import static seedu.address.logic.parser.CliSyntax.PREFIX_DECK;
-
-import java.util.stream.Stream;
-
 import seedu.address.logic.commands.AddDeckCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.deck.Deck;

--- a/src/main/java/seedu/address/logic/parser/AddDeckCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddDeckCommandParser.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DECK;
+//import static seedu.address.logic.parser.CliSyntax.PREFIX_DECK;
 
 import java.util.stream.Stream;
 
@@ -21,24 +21,11 @@ public class AddDeckCommandParser implements Parser<AddDeckCommand> {
      */
     public AddDeckCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_DECK);
+                ArgumentTokenizer.tokenize(args);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_DECK)
-                || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddDeckCommand.MESSAGE_USAGE));
-        }
-
-        Deck deck = ParserUtil.parseDeck(argMultimap.getValue(PREFIX_DECK).get());
+        Deck deck = ParserUtil.parseDeck(args);
 
         return new AddDeckCommand(deck);
-    }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -9,6 +9,5 @@ public class CliSyntax {
     public static final Prefix PREFIX_QUESTION = new Prefix("q/");
     public static final Prefix PREFIX_ANSWER = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
-    public static final Prefix PREFIX_DECK = new Prefix("d/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteDeckCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteDeckCommandParser.java
@@ -1,0 +1,34 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.DeleteDeckCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new DeleteDeck object
+ */
+public class DeleteDeckCommandParser implements Parser<DeleteDeckCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteDeckCommand
+     * and returns an DeleteDeckCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public DeleteDeckCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args);
+
+        Index index;
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    DeleteDeckCommand.MESSAGE_USAGE), pe);
+        }
+
+        return new DeleteDeckCommand(index);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/EditDeckCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditDeckCommandParser.java
@@ -2,10 +2,10 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DECK;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditDeckCommand;
+import seedu.address.logic.commands.SelectDeckCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.deck.Deck;
 
@@ -21,19 +21,19 @@ public class EditDeckCommandParser implements Parser<EditDeckCommand> {
      */
     public EditDeckCommand parse(String args) throws ParseException {
         requireNonNull(args);
-
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_DECK);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args);
 
         Index index;
 
         try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+            String i = String.valueOf(args.charAt(1));
+            index = ParserUtil.parseIndex(i);
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditDeckCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    SelectDeckCommand.MESSAGE_USAGE), pe);
         }
 
-        Deck editedDeck = ParserUtil.parseDeck(argMultimap.getValue(PREFIX_DECK).get());
+        Deck editedDeck = ParserUtil.parseDeck(args.substring(2));
 
         return new EditDeckCommand(index, editedDeck);
     }

--- a/src/main/java/seedu/address/logic/parser/MasterDeckParser.java
+++ b/src/main/java/seedu/address/logic/parser/MasterDeckParser.java
@@ -11,6 +11,7 @@ import seedu.address.logic.commands.AddDeckCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteDeckCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditDeckCommand;
 import seedu.address.logic.commands.EndReviewCommand;
@@ -56,6 +57,9 @@ public class MasterDeckParser {
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();
+
+        case DeleteDeckCommand.COMMAND_WORD:
+            return new DeleteDeckCommandParser().parse(arguments);
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/model/MasterDeck.java
+++ b/src/main/java/seedu/address/model/MasterDeck.java
@@ -152,9 +152,9 @@ public class MasterDeck implements ReadOnlyMasterDeck {
      */
     public void removeDeck(Deck key) {
         ArrayList<Card> remCards = new ArrayList<>();
-        for(Card c : cards) {
+        for (Card c : cards) {
             Deck targetDeck = c.getDeck().isPresent() ? c.getDeck().get() : new Deck("");
-            if(targetDeck.getDeckName().equals(key.getDeckName())) {
+            if (targetDeck.getDeckName().equals(key.getDeckName())) {
                 remCards.add(c);
             }
         }

--- a/src/main/java/seedu/address/model/MasterDeck.java
+++ b/src/main/java/seedu/address/model/MasterDeck.java
@@ -2,6 +2,7 @@ package seedu.address.model;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import javafx.collections.ObservableList;
@@ -97,7 +98,7 @@ public class MasterDeck implements ReadOnlyMasterDeck {
 
     /**
      * Removes {@code key} from this {@code Deck}.
-     * {@code key} must exist in the address book.
+     * {@code key} must exist in the MasterDeck.
      */
     public void removeCard(Card key) {
         cards.remove(key);
@@ -150,6 +151,16 @@ public class MasterDeck implements ReadOnlyMasterDeck {
      * {@code key} must exist.
      */
     public void removeDeck(Deck key) {
+        ArrayList<Card> remCards = new ArrayList<>();
+        for(Card c : cards) {
+            Deck targetDeck = c.getDeck().isPresent() ? c.getDeck().get() : new Deck("");
+            if(targetDeck.getDeckName().equals(key.getDeckName())) {
+                remCards.add(c);
+            }
+        }
+        for (Card r : remCards) {
+            removeCard(r);
+        }
         decks.remove(key);
     }
 

--- a/src/main/java/seedu/address/model/MasterDeck.java
+++ b/src/main/java/seedu/address/model/MasterDeck.java
@@ -153,8 +153,8 @@ public class MasterDeck implements ReadOnlyMasterDeck {
     public void removeDeck(Deck key) {
         ArrayList<Card> remCards = new ArrayList<>();
         for (Card c : cards) {
-            Deck targetDeck = c.getDeck().isPresent() ? c.getDeck().get() : new Deck("");
-            if (targetDeck.getDeckName().equals(key.getDeckName())) {
+            Deck targetDeck = c.getDeck().orElse(new Deck(""));
+            if (targetDeck.equals(key)) {
                 remCards.add(c);
             }
         }


### PR DESCRIPTION
- Remove PREFIX_DECK from AddDeckCommand and EditDeckCommand

- No need to type a prefix (/d) for deck commands anymore

- DeleteDeckCommand added to delete a deck by its index. Cards in the deck are also deleted together.

Closes #84 and #93  