### PR TITLE
[TEST] CI will now fail if code coverage not successful 

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -43,4 +43,4 @@ jobs:
         with:
           directory: ${{ github.workspace }}/build/reports/jacoco/coverage
           files: coverage.xml
-          fail_ci_if_error: false
+          fail_ci_if_error: true


### PR DESCRIPTION
I'm not 100% sure how this works but if I recall it will check for code coverages and fail if new code reduces the code coverage. I have attached screenshots below. I think we can have this now since most of our features are done. Anyway, it is easy to revert this change (just change back to false). 

Example on PR
![Screenshot 2023-03-15 at 19 20 35](https://user-images.githubusercontent.com/85063215/225294394-10bd40af-9cc1-4212-85ec-e9a98e7be504.png)
