### PR TITLE
Allow decks to be saved in JSON format

### DIFF
--- a/src/main/java/seedu/address/model/MasterDeck.java
+++ b/src/main/java/seedu/address/model/MasterDeck.java
@@ -113,11 +113,10 @@ public class MasterDeck implements ReadOnlyMasterDeck {
      * hence this function should not be called in normal operation.
      */
     public void initDecks() {
-        for (Card card: cards) {
-            if (!decks.contains(card.getDeck().get())) {
-                addDeck(card.getDeck().get());
-            }
-        }
+        cards.asUnmodifiableObservableList().stream()
+                .map(card -> card.getDeck().get())
+                .distinct()
+                .forEach(this::addDeck);
     }
 
     /**

--- a/src/main/java/seedu/address/model/MasterDeck.java
+++ b/src/main/java/seedu/address/model/MasterDeck.java
@@ -128,8 +128,8 @@ public class MasterDeck implements ReadOnlyMasterDeck {
     }
 
     /**
-     * Adds a card to the address book.
-     * The card must not already exist in the address book.
+     * Adds a card to the masterDeck.
+     * The card must not already exist in the masterDeck.
      */
     public void addDeck(Deck d) {
         decks.add(d);
@@ -183,7 +183,8 @@ public class MasterDeck implements ReadOnlyMasterDeck {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof MasterDeck // instanceof handles nulls
-                && cards.equals(((MasterDeck) other).cards));
+                && cards.equals(((MasterDeck) other).cards)
+                && decks.equals(((MasterDeck) other).decks));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/deck/Deck.java
+++ b/src/main/java/seedu/address/model/deck/Deck.java
@@ -65,20 +65,9 @@ public class Deck {
         return Objects.hash(deckName);
     }
 
-    /*
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder();
-        builder.append(getQuestion())
-                .append("; Answer: ")
-                .append(getAddress());
-
-        Set<Tag> tags = getTags();
-        if (!tags.isEmpty()) {
-            builder.append("; Tags: ");
-            tags.forEach(builder::append);
-        }
-        return builder.toString();
+        return this.deckName;
     }
-     */
+
 }

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -17,26 +17,29 @@ import seedu.address.model.tag.Tag;
  * Contains utility methods for populating {@code Deck} with sample data.
  */
 public class SampleDataUtil {
-    public static Card[] getSampleCards() {
-        return new Card[] {
-            new Card(new Question("Alex Yeoh"),
-                    new Answer("Blk 30 Geylang Street 29, #06-40"),
-                getTagSet("friends"), Optional.of(new Deck("Default Deck"))),
-            new Card(new Question("Bernice Yu"),
-                new Answer("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
-                getTagSet("colleagues", "friends"), Optional.of(new Deck("Default Deck"))),
-            new Card(new Question("Charlotte Oliveiro"),
-                new Answer("Blk 11 Ang Mo Kio Street 74, #11-04"),
-                getTagSet("neighbours"), Optional.of(new Deck("Default Deck"))),
-            new Card(new Question("David Li"),
-                new Answer("Blk 436 Serangoon Gardens Street 26, #16-43"),
-                getTagSet("family"), Optional.of(new Deck("Default Deck"))),
-            new Card(new Question("Irfan Ibrahim"),
-                new Answer("Blk 47 Tampines Street 20, #17-35"),
-                getTagSet("classmates"), Optional.of(new Deck("Default Deck"))),
-            new Card(new Question("Roy Balakrishnan"),
-                new Answer("Blk 45 Aljunied Street 85, #11-31"),
-                getTagSet("colleagues"), Optional.of(new Deck("Default Deck")))
+    private static final Deck defaultDeck = new Deck("Default Deck");
+
+    public static Card[] getSampleCards() { // Todo: initilize new cards?
+        return new Card[]{
+            new Card(new Question("What is a loop"),
+                    new Answer("A construct that repeats instructions until a condition is met"),
+                    getTagSet("easy"), Optional.of(defaultDeck)),
+            new Card(new Question("What is a variable"),
+                    new Answer("A named memory location that stores a value"),
+                    getTagSet("easy"), Optional.of(defaultDeck)),
+            new Card(new Question("What is the structure of an atom"),
+                    new Answer("Atoms consist of a nucleus containing protons and neutrons, "
+                            + "surrounded by electrons in shells or energy levels"),
+                    getTagSet("medium"), Optional.of(defaultDeck)),
+            new Card(new Question("What is the basic unit of life"),
+                    new Answer("The cell is the basic unit of life"),
+                    getTagSet("easy"), Optional.of(defaultDeck)),
+            new Card(new Question("Who was the first president of the United States"),
+                    new Answer("George Washington"),
+                    getTagSet("medium"), Optional.of(defaultDeck)),
+            new Card(new Question("When did Singapore gain independence"),
+                    new Answer("9 August 1965"),
+                    getTagSet("hard"), Optional.of(defaultDeck))
         };
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedDeck.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedDeck.java
@@ -1,0 +1,48 @@
+package seedu.address.storage;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.card.Question;
+import seedu.address.model.deck.Deck;
+
+/**
+ * Jackson-friendly version of {@link Deck}.
+ */
+public class JsonAdaptedDeck {
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Deck name is missing!";
+    private final String deckName;
+
+    /**
+     * Constructs a {@code JsonAdaptedDeck} with the given deck details.
+     */
+    @JsonCreator
+    public JsonAdaptedDeck(@JsonProperty("deckName") String deckName) {
+        this.deckName = deckName;
+    }
+
+    /**
+     * Converts a given {@code Deck} into this class for Jackson use.
+     */
+    public JsonAdaptedDeck(Deck source) {
+        this.deckName = source.getDeckName();
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted Deck object into the model's {@code Deck} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted deck.
+     */
+    public Deck toModelType() throws IllegalValueException {
+
+        if (deckName == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT));
+        }
+        if (!Question.isValidQuestion(deckName)) { // Todo: any constraints on Deck Name?
+            throw new IllegalValueException(Question.MESSAGE_CONSTRAINTS);
+        }
+
+        return new Deck(deckName);
+    }
+}

--- a/src/main/java/seedu/address/storage/JsonAddressBookStorage.java
+++ b/src/main/java/seedu/address/storage/JsonAddressBookStorage.java
@@ -45,8 +45,8 @@ public class JsonAddressBookStorage implements AddressBookStorage {
     public Optional<ReadOnlyMasterDeck> readAddressBook(Path filePath) throws DataConversionException {
         requireNonNull(filePath);
 
-        Optional<JsonSerializableAddressBook> jsonAddressBook = JsonUtil.readJsonFile(
-                filePath, JsonSerializableAddressBook.class);
+        Optional<JsonSerializableMasterDeck> jsonAddressBook = JsonUtil.readJsonFile(
+                filePath, JsonSerializableMasterDeck.class);
         if (!jsonAddressBook.isPresent()) {
             return Optional.empty();
         }
@@ -73,7 +73,7 @@ public class JsonAddressBookStorage implements AddressBookStorage {
         requireNonNull(addressBook);
         requireNonNull(filePath);
         FileUtil.createIfMissing(filePath);
-        JsonUtil.saveJsonFile(new JsonSerializableAddressBook(addressBook), filePath);
+        JsonUtil.saveJsonFile(new JsonSerializableMasterDeck(addressBook), filePath);
     }
 
 }

--- a/src/main/java/seedu/address/storage/JsonSerializableMasterDeck.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableMasterDeck.java
@@ -22,6 +22,7 @@ class JsonSerializableMasterDeck {
 
     public static final String MESSAGE_DUPLICATE_PERSON = "Card list contains duplicate card(s).";
     public static final String MESSAGE_DUPLICATE_DECK = "Deck list contains duplicate deck(s).";
+    public static final String MESSAGE_MISSING_DECK = "Some cards exist without an existing deck.";
 
     private final List<JsonAdaptedCard> cards = new ArrayList<>();
     private final List<JsonAdaptedDeck> decks = new ArrayList<>();
@@ -67,6 +68,12 @@ class JsonSerializableMasterDeck {
             if (masterDeck.hasCard(card)) {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_PERSON);
             }
+
+            Deck currDeck = card.getDeck().get();
+            if (!masterDeck.hasDeck(currDeck)) {
+                throw new IllegalValueException(MESSAGE_MISSING_DECK);
+            }
+
             masterDeck.addCard(card);
         }
 

--- a/src/main/java/seedu/address/storage/JsonSerializableMasterDeck.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableMasterDeck.java
@@ -18,7 +18,7 @@ import seedu.address.model.deck.Deck;
  * An Immutable Deck that is serializable to JSON format.
  */
 @JsonRootName(value = "addressbook")
-class JsonSerializableAddressBook {
+class JsonSerializableMasterDeck {
 
     public static final String MESSAGE_DUPLICATE_PERSON = "Card list contains duplicate card(s).";
     public static final String MESSAGE_DUPLICATE_DECK = "Deck list contains duplicate deck(s).";
@@ -27,11 +27,11 @@ class JsonSerializableAddressBook {
     private final List<JsonAdaptedDeck> decks = new ArrayList<>();
 
     /**
-     * Constructs a {@code JsonSerializableAddressBook} with the given persons.
+     * Constructs a {@code JsonSerializableMasterDeck} with the given persons.
      */
     @JsonCreator
-    public JsonSerializableAddressBook(@JsonProperty("cards") List<JsonAdaptedCard> cards,
-                                       @JsonProperty("decks") List<JsonAdaptedDeck> decks) {
+    public JsonSerializableMasterDeck(@JsonProperty("cards") List<JsonAdaptedCard> cards,
+                                      @JsonProperty("decks") List<JsonAdaptedDeck> decks) {
         this.cards.addAll(cards);
         this.decks.addAll(decks);
     }
@@ -39,9 +39,9 @@ class JsonSerializableAddressBook {
     /**
      * Converts a given {@code ReadOnlyDeck} into this class for Jackson use.
      *
-     * @param source future changes to this will not affect the created {@code JsonSerializableAddressBook}.
+     * @param source future changes to this will not affect the created {@code JsonSerializableMasterDeck}.
      */
-    public JsonSerializableAddressBook(ReadOnlyMasterDeck source) {
+    public JsonSerializableMasterDeck(ReadOnlyMasterDeck source) {
         cards.addAll(source.getCardList().stream().map(JsonAdaptedCard::new).collect(Collectors.toList()));
         decks.addAll(source.getDeckList().stream().map(JsonAdaptedDeck::new).collect(Collectors.toList()));
     }

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -8,5 +8,8 @@
     "question": "Alice Pauline",
     "answer": "4th street",
     "deck" : "Default"
+  } ],
+  "decks" : [ {
+    "deckName" : "Default"
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
@@ -1,7 +1,10 @@
 {
   "cards": [ {
-    "question": "Hans Muster",
-    "answer": "4th street",
+    "question": "!nvalid question",
+    "answer": " Invalid answer",
     "deck" : "Default"
+  } ],
+  "decks" : [ {
+    "deckName" : "Default"
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/missingDeckMasterDeck.json
+++ b/src/test/data/JsonSerializableAddressBookTest/missingDeckMasterDeck.json
@@ -1,0 +1,11 @@
+{
+  "cards": [ {
+    "question": "Como estas usted",
+    "answer": "Muy bien",
+    "tagged": [ "easy" ],
+    "deck" : "MISSING"
+  } ],
+  "decks" : [ {
+    "deckName" : "Default"
+  } ]
+}

--- a/src/test/data/JsonSerializableAddressBookTest/typicalCardsMasterDeck.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalCardsMasterDeck.json
@@ -35,5 +35,14 @@
     "answer": "An earthquake is a sudden and rapid shaking of the earth caused by the shifting of tectonic plates",
     "tagged" : [ ],
     "deck" : "Geography"
+  } ],
+  "decks" : [ {
+    "deckName" : "Programming Concepts"
+  }, {
+    "deckName" : "Science"
+  }, {
+    "deckName" : "History"
+  }, {
+    "deckName" : "Geography"
   } ]
 }

--- a/src/test/java/seedu/address/storage/JsonMasterDeckStorageTest.java
+++ b/src/test/java/seedu/address/storage/JsonMasterDeckStorageTest.java
@@ -3,7 +3,7 @@ package seedu.address.storage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalCards.FRACTION;
+import static seedu.address.testutil.TypicalCards.GRAVITY;
 import static seedu.address.testutil.TypicalCards.LOOP;
 import static seedu.address.testutil.TypicalCards.SMOG;
 import static seedu.address.testutil.TypicalCards.getTypicalMasterDeck;
@@ -80,7 +80,7 @@ public class JsonMasterDeckStorageTest {
         assertEquals(original, new MasterDeck(readBack));
 
         // Save and read without specifying file path
-        original.addCard(FRACTION);
+        original.addCard(GRAVITY);
         jsonAddressBookStorage.saveAddressBook(original); // file path not specified
         readBack = jsonAddressBookStorage.readAddressBook().get(); // file path not specified
         assertEquals(original, new MasterDeck(readBack));

--- a/src/test/java/seedu/address/storage/JsonSerializableMasterDeckTest.java
+++ b/src/test/java/seedu/address/storage/JsonSerializableMasterDeckTest.java
@@ -23,8 +23,8 @@ public class JsonSerializableMasterDeckTest {
 
     @Test
     public void toModelType_typicalCardsFile_success() throws Exception {
-        JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(TYPICAL_CARDS_FILE,
-                JsonSerializableAddressBook.class).get();
+        JsonSerializableMasterDeck dataFromFile = JsonUtil.readJsonFile(TYPICAL_CARDS_FILE,
+                JsonSerializableMasterDeck.class).get();
         MasterDeck addressBookFromFile = dataFromFile.toModelType();
         MasterDeck typicalPersonsAddressBook = TypicalCards.getTypicalMasterDeck();
         assertEquals(addressBookFromFile, typicalPersonsAddressBook);
@@ -32,16 +32,16 @@ public class JsonSerializableMasterDeckTest {
 
     @Test
     public void toModelType_invalidPersonFile_throwsIllegalValueException() throws Exception {
-        JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(INVALID_CARD_FILE,
-                JsonSerializableAddressBook.class).get();
+        JsonSerializableMasterDeck dataFromFile = JsonUtil.readJsonFile(INVALID_CARD_FILE,
+                JsonSerializableMasterDeck.class).get();
         assertThrows(IllegalValueException.class, dataFromFile::toModelType);
     }
 
     @Test
     public void toModelType_duplicateCards_throwsIllegalValueException() throws Exception {
-        JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(DUPLICATE_CARD_FILE,
-                JsonSerializableAddressBook.class).get();
-        assertThrows(IllegalValueException.class, JsonSerializableAddressBook.MESSAGE_DUPLICATE_PERSON,
+        JsonSerializableMasterDeck dataFromFile = JsonUtil.readJsonFile(DUPLICATE_CARD_FILE,
+                JsonSerializableMasterDeck.class).get();
+        assertThrows(IllegalValueException.class, JsonSerializableMasterDeck.MESSAGE_DUPLICATE_PERSON,
                 dataFromFile::toModelType);
     }
 

--- a/src/test/java/seedu/address/storage/JsonSerializableMasterDeckTest.java
+++ b/src/test/java/seedu/address/storage/JsonSerializableMasterDeckTest.java
@@ -30,12 +30,12 @@ public class JsonSerializableMasterDeckTest {
         assertEquals(addressBookFromFile, typicalPersonsAddressBook);
     }
 
-    //    @Test
-    //    public void toModelType_invalidPersonFile_throwsIllegalValueException() throws Exception {
-    //        JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(INVALID_CARD_FILE,
-    //                JsonSerializableAddressBook.class).get();
-    //        assertThrows(IllegalValueException.class, dataFromFile::toModelType);
-    //    }
+    @Test
+    public void toModelType_invalidPersonFile_throwsIllegalValueException() throws Exception {
+        JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(INVALID_CARD_FILE,
+                JsonSerializableAddressBook.class).get();
+        assertThrows(IllegalValueException.class, dataFromFile::toModelType);
+    }
 
     @Test
     public void toModelType_duplicateCards_throwsIllegalValueException() throws Exception {

--- a/src/test/java/seedu/address/storage/JsonSerializableMasterDeckTest.java
+++ b/src/test/java/seedu/address/storage/JsonSerializableMasterDeckTest.java
@@ -20,6 +20,7 @@ public class JsonSerializableMasterDeckTest {
     private static final Path TYPICAL_CARDS_FILE = TEST_DATA_FOLDER.resolve("typicalCardsMasterDeck.json");
     private static final Path INVALID_CARD_FILE = TEST_DATA_FOLDER.resolve("invalidPersonAddressBook.json");
     private static final Path DUPLICATE_CARD_FILE = TEST_DATA_FOLDER.resolve("duplicatePersonAddressBook.json");
+    private static final Path MISSING_DECK_FILE = TEST_DATA_FOLDER.resolve("missingDeckMasterDeck.json");
 
     @Test
     public void toModelType_typicalCardsFile_success() throws Exception {
@@ -42,6 +43,14 @@ public class JsonSerializableMasterDeckTest {
         JsonSerializableMasterDeck dataFromFile = JsonUtil.readJsonFile(DUPLICATE_CARD_FILE,
                 JsonSerializableMasterDeck.class).get();
         assertThrows(IllegalValueException.class, JsonSerializableMasterDeck.MESSAGE_DUPLICATE_PERSON,
+                dataFromFile::toModelType);
+    }
+
+    @Test
+    public void toModelType_cardExistsWithoutDeck_throwsIllegalValueException() throws Exception {
+        JsonSerializableMasterDeck dataFromFile = JsonUtil.readJsonFile(MISSING_DECK_FILE,
+                JsonSerializableMasterDeck.class).get();
+        assertThrows(IllegalValueException.class, JsonSerializableMasterDeck.MESSAGE_MISSING_DECK,
                 dataFromFile::toModelType);
     }
 

--- a/src/test/java/seedu/address/testutil/TypicalCards.java
+++ b/src/test/java/seedu/address/testutil/TypicalCards.java
@@ -66,12 +66,12 @@ public class TypicalCards {
      * Returns an {@code Deck} with all the typical cards.
      */
     public static MasterDeck getTypicalMasterDeck() {
-        MasterDeck ab = new MasterDeck();
+        MasterDeck masterDeck = new MasterDeck();
         for (Card card : getTypicalCards()) {
-            ab.addCard(card);
+            masterDeck.addCard(card);
         }
-        ab.initDecks();
-        return ab;
+        masterDeck.initDecks();
+        return masterDeck;
     }
 
     public static List<Card> getTypicalCards() {


### PR DESCRIPTION
Allow decks to be saved in JSON format. Other changes include:
- Allow decks with no card to be saved and loaded in the next session.
- Throw exception if a JSON card exists without an existing deck.
    - Add a test case for this behaviour
- Modify equal method in MasterDeck to compare deck list too.
- Reformat JsonSerializableAddressBook to JsonSerializableMasterDeck.
- Reformat the SampleDataUtil from Persons information to Cards information.


Note:
- Delete your addressbook.json file before loading the app, the old data should be in incorrect format (no JSON deck).
- Some test methods were adding cards without creating a deck, through the MasterDeck::addCard method. Should we modify addCard so that if we add a card, we also add a deck if the deck is not found?

Closes #105 