### PR TITLE
Update token to use backslash

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditDeckCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditDeckCommand.java
@@ -27,7 +27,7 @@ public class EditDeckCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1 "
             + "LAC1201";
 
-    public static final String MESSAGE_EDIT_DECK_SUCCESS = "Edited Deck: %1$s";
+    public static final String MESSAGE_EDIT_DECK_SUCCESS = "Successfully renamed deck to %1$s";
     public static final String MESSAGE_DUPLICATE_DECK = "This deck name already exists.";
 
     private final Index index;

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -6,8 +6,8 @@ package seedu.address.logic.parser;
 public class CliSyntax {
 
     /* Prefix definitions */
-    public static final Prefix PREFIX_QUESTION = new Prefix("q/");
-    public static final Prefix PREFIX_ANSWER = new Prefix("a/");
-    public static final Prefix PREFIX_TAG = new Prefix("t/");
+    public static final Prefix PREFIX_QUESTION = new Prefix("q\\");
+    public static final Prefix PREFIX_ANSWER = new Prefix("a\\");
+    public static final Prefix PREFIX_TAG = new Prefix("t\\");
 
 }


### PR DESCRIPTION
Addresses #115 

New usage: add q\myquestion a\myanswer
Single backslash for the prefixes.

Limitation: Users who want to use backslash in their questions or answer might find unexpected behaviour if they include the prefixes in their question, answer or tag.

Leaving #115 open in case we think of a better idea to reduce ambiguity