### PR TITLE
Refactor Card class constructor to take in Deck instead of Optional<Deck>

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -5,12 +5,18 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ANSWER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_QUESTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.card.Answer;
 import seedu.address.model.card.Card;
+import seedu.address.model.card.Question;
 import seedu.address.model.deck.Deck;
+import seedu.address.model.tag.Tag;
 
 /**
  * Adds a card to the selected deck.
@@ -31,6 +37,7 @@ public class AddCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "New card added: %1$s";
     public static final String MESSAGE_DUPLICATE_CARD = "This card already exists in the master deck";
+    public static final String MESSAGE_NO_SELECTED_DECK = "A deck must be selected before a card can be added";
 
     private final Card toAdd;
 
@@ -49,7 +56,12 @@ public class AddCommand extends Command {
         if (model.hasCard(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_CARD);
         }
-        toAdd.setDeck(selectedDeck);
+
+        if (selectedDeck.isEmpty()) {
+            throw new CommandException(MESSAGE_NO_SELECTED_DECK);
+        }
+
+        toAdd.setDeck(selectedDeck.get());
         model.addCard(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
     }
@@ -59,5 +71,80 @@ public class AddCommand extends Command {
         return other == this // short circuit if same object
                 || (other instanceof AddCommand // instanceof handles nulls
                 && toAdd.equals(((AddCommand) other).toAdd));
+    }
+
+    /**
+     * Stores the details to add a card without a deck assigned.
+     */
+    public static class AddCardDescriptor {
+        private Question question;
+        private Answer answer;
+        private Set<Tag> tags;
+
+
+        public AddCardDescriptor() {}
+
+        /**
+         * Copy constructor.
+         * A defensive copy of {@code tags} is used internally.
+         */
+        public AddCardDescriptor(AddCommand.AddCardDescriptor toCopy) {
+            setQuestion(toCopy.question);
+            setAnswer(toCopy.answer);
+            setTags(toCopy.tags);
+        }
+
+        public void setQuestion(Question question) {
+            this.question = question;
+        }
+
+        public Question getQuestion() {
+            return question;
+        }
+
+        public void setAnswer(Answer answer) {
+            this.answer = answer;
+        }
+
+        public Answer getAnswer() {
+            return answer;
+        }
+
+        /**
+         * Sets {@code tags} to this object's {@code tags}.
+         * A defensive copy of {@code tags} is used internally.
+         */
+        public void setTags(Set<Tag> tags) {
+            this.tags = (tags != null) ? new HashSet<>(tags) : null;
+        }
+
+        /**
+         * Returns an unmodifiable tag set, which throws {@code UnsupportedOperationException}
+         * if modification is attempted.
+         * Returns {@code Optional#empty()} if {@code tags} is null.
+         */
+        public Optional<Set<Tag>> getTags() {
+            return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            // short circuit if same object
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(other instanceof AddCommand.AddCardDescriptor)) {
+                return false;
+            }
+
+            // state check
+            AddCommand.AddCardDescriptor e = (AddCommand.AddCardDescriptor) other;
+
+            return getQuestion().equals(e.getQuestion())
+                    && getAnswer().equals(e.getAnswer())
+                    && getTags().equals(e.getTags());
+        }
     }
 }

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -5,18 +5,12 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ANSWER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_QUESTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Optional;
-import java.util.Set;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.card.Answer;
 import seedu.address.model.card.Card;
-import seedu.address.model.card.Question;
 import seedu.address.model.deck.Deck;
-import seedu.address.model.tag.Tag;
 
 /**
  * Adds a card to the selected deck.
@@ -73,78 +67,78 @@ public class AddCommand extends Command {
                 && toAdd.equals(((AddCommand) other).toAdd));
     }
 
-    /**
-     * Stores the details to add a card without a deck assigned.
-     */
-    public static class AddCardDescriptor {
-        private Question question;
-        private Answer answer;
-        private Set<Tag> tags;
-
-
-        public AddCardDescriptor() {}
-
-        /**
-         * Copy constructor.
-         * A defensive copy of {@code tags} is used internally.
-         */
-        public AddCardDescriptor(AddCommand.AddCardDescriptor toCopy) {
-            setQuestion(toCopy.question);
-            setAnswer(toCopy.answer);
-            setTags(toCopy.tags);
-        }
-
-        public void setQuestion(Question question) {
-            this.question = question;
-        }
-
-        public Question getQuestion() {
-            return question;
-        }
-
-        public void setAnswer(Answer answer) {
-            this.answer = answer;
-        }
-
-        public Answer getAnswer() {
-            return answer;
-        }
-
-        /**
-         * Sets {@code tags} to this object's {@code tags}.
-         * A defensive copy of {@code tags} is used internally.
-         */
-        public void setTags(Set<Tag> tags) {
-            this.tags = (tags != null) ? new HashSet<>(tags) : null;
-        }
-
-        /**
-         * Returns an unmodifiable tag set, which throws {@code UnsupportedOperationException}
-         * if modification is attempted.
-         * Returns {@code Optional#empty()} if {@code tags} is null.
-         */
-        public Optional<Set<Tag>> getTags() {
-            return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
-        }
-
-        @Override
-        public boolean equals(Object other) {
-            // short circuit if same object
-            if (other == this) {
-                return true;
-            }
-
-            // instanceof handles nulls
-            if (!(other instanceof AddCommand.AddCardDescriptor)) {
-                return false;
-            }
-
-            // state check
-            AddCommand.AddCardDescriptor e = (AddCommand.AddCardDescriptor) other;
-
-            return getQuestion().equals(e.getQuestion())
-                    && getAnswer().equals(e.getAnswer())
-                    && getTags().equals(e.getTags());
-        }
-    }
+    //    /**
+    //     * Stores the details to add a card without a deck assigned.
+    //     */
+    //    public static class AddCardDescriptor {
+    //        private Question question;
+    //        private Answer answer;
+    //        private Set<Tag> tags;
+    //
+    //
+    //        public AddCardDescriptor() {}
+    //
+    //        /**
+    //         * Copy constructor.
+    //         * A defensive copy of {@code tags} is used internally.
+    //         */
+    //        public AddCardDescriptor(AddCommand.AddCardDescriptor toCopy) {
+    //            setQuestion(toCopy.question);
+    //            setAnswer(toCopy.answer);
+    //            setTags(toCopy.tags);
+    //        }
+    //
+    //        public void setQuestion(Question question) {
+    //            this.question = question;
+    //        }
+    //
+    //        public Question getQuestion() {
+    //            return question;
+    //        }
+    //
+    //        public void setAnswer(Answer answer) {
+    //            this.answer = answer;
+    //        }
+    //
+    //        public Answer getAnswer() {
+    //            return answer;
+    //        }
+    //
+    //        /**
+    //         * Sets {@code tags} to this object's {@code tags}.
+    //         * A defensive copy of {@code tags} is used internally.
+    //         */
+    //        public void setTags(Set<Tag> tags) {
+    //            this.tags = (tags != null) ? new HashSet<>(tags) : null;
+    //        }
+    //
+    //        /**
+    //         * Returns an unmodifiable tag set, which throws {@code UnsupportedOperationException}
+    //         * if modification is attempted.
+    //         * Returns {@code Optional#empty()} if {@code tags} is null.
+    //         */
+    //        public Optional<Set<Tag>> getTags() {
+    //            return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
+    //        }
+    //
+    //        @Override
+    //        public boolean equals(Object other) {
+    //            // short circuit if same object
+    //            if (other == this) {
+    //                return true;
+    //            }
+    //
+    //            // instanceof handles nulls
+    //            if (!(other instanceof AddCommand.AddCardDescriptor)) {
+    //                return false;
+    //            }
+    //
+    //            // state check
+    //            AddCommand.AddCardDescriptor e = (AddCommand.AddCardDescriptor) other;
+    //
+    //            return getQuestion().equals(e.getQuestion())
+    //                    && getAnswer().equals(e.getAnswer())
+    //                    && getTags().equals(e.getTags());
+    //        }
+    //    }
 }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -87,7 +87,9 @@ public class EditCommand extends Command {
         Question updatedQuestion = editCardDescriptor.getQuestion().orElse(cardToEdit.getQuestion());
         Answer updatedAnswer = editCardDescriptor.getAnswer().orElse(cardToEdit.getAnswer());
         Set<Tag> updatedTags = editCardDescriptor.getTags().orElse(cardToEdit.getTags());
-        Optional<Deck> updatedDeck = editCardDescriptor.getDeck().orElse(Optional.of(cardToEdit.getDeck().get()));
+
+        assert cardToEdit.getDeck().isPresent() : "The edited card must be inside a deck";
+        Deck updatedDeck = editCardDescriptor.getDeck().orElse(cardToEdit.getDeck().get());
 
         return new Card(updatedQuestion, updatedAnswer, updatedTags, updatedDeck);
     }
@@ -118,7 +120,7 @@ public class EditCommand extends Command {
         private Question question;
         private Answer answer;
         private Set<Tag> tags;
-        private Optional<Deck> deck;
+        private Deck deck;
 
         public EditCardDescriptor() {}
 
@@ -155,10 +157,12 @@ public class EditCommand extends Command {
         public Optional<Answer> getAnswer() {
             return Optional.ofNullable(answer);
         }
-        public void setDeck(Optional<Deck> deck) {
+
+        public void setDeck(Deck deck) {
             this.deck = deck;
         }
-        public Optional<Optional<Deck>> getDeck() {
+
+        public Optional<Deck> getDeck() {
             return Optional.ofNullable(deck);
         }
 

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -5,7 +5,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ANSWER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_QUESTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -39,7 +38,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         Answer answer = ParserUtil.parseAnswer(argMultimap.getValue(PREFIX_ANSWER).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
-        Card card = new Card(question, answer, tagList, Optional.empty());
+        Card card = new Card(question, answer, tagList, null);
 
         return new AddCommand(card);
     }
@@ -51,5 +50,4 @@ public class AddCommandParser implements Parser<AddCommand> {
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
-
 }

--- a/src/main/java/seedu/address/model/card/Card.java
+++ b/src/main/java/seedu/address/model/card/Card.java
@@ -23,13 +23,13 @@ public class Card {
     // Data fields
     private final Answer answer;
     private final Set<Tag> tags = new HashSet<>();
-    private Optional<Deck> deck;
+    private Deck deck;
     private boolean isFlipped = true;
 
     /**
      * Every field must be present and not null.
      */
-    public Card(Question question, Answer answer, Set<Tag> tags, Optional<Deck> deck) {
+    public Card(Question question, Answer answer, Set<Tag> tags, Deck deck) {
         requireAllNonNull(question, answer, tags);
         this.question = question;
         this.answer = answer;
@@ -54,10 +54,10 @@ public class Card {
     }
 
     public Optional<Deck> getDeck() {
-        return deck;
+        return Optional.of(deck);
     }
 
-    public void setDeck(Optional<Deck> newDeck) {
+    public void setDeck(Deck newDeck) {
         this.deck = newDeck;
     }
 

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -16,29 +16,29 @@ import seedu.address.model.tag.Tag;
  * Contains utility methods for populating {@code Deck} with sample data.
  */
 public class SampleDataUtil {
-    private static final Deck defaultDeck = new Deck("Default Deck");
+    private static final Deck DEFAULT_DECK = new Deck("DEFAULT DECK");
 
     public static Card[] getSampleCards() { // Todo: initilize new cards?
         return new Card[]{
             new Card(new Question("What is a loop"),
                     new Answer("A construct that repeats instructions until a condition is met"),
-                    getTagSet("easy"), defaultDeck),
+                    getTagSet("easy"), DEFAULT_DECK),
             new Card(new Question("What is a variable"),
                     new Answer("A named memory location that stores a value"),
-                    getTagSet("easy"), defaultDeck),
+                    getTagSet("easy"), DEFAULT_DECK),
             new Card(new Question("What is the structure of an atom"),
                     new Answer("Atoms consist of a nucleus containing protons and neutrons, "
                             + "surrounded by electrons in shells or energy levels"),
-                    getTagSet("medium"), defaultDeck),
+                    getTagSet("medium"), DEFAULT_DECK),
             new Card(new Question("What is the basic unit of life"),
                     new Answer("The cell is the basic unit of life"),
-                    getTagSet("easy"), defaultDeck),
+                    getTagSet("easy"), DEFAULT_DECK),
             new Card(new Question("Who was the first president of the United States"),
                     new Answer("George Washington"),
-                    getTagSet("medium"), defaultDeck),
+                    getTagSet("medium"), DEFAULT_DECK),
             new Card(new Question("When did Singapore gain independence"),
                     new Answer("9 August 1965"),
-                    getTagSet("hard"), defaultDeck)
+                    getTagSet("hard"), DEFAULT_DECK)
         };
     }
 

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -1,7 +1,6 @@
 package seedu.address.model.util;
 
 import java.util.Arrays;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -23,23 +22,23 @@ public class SampleDataUtil {
         return new Card[]{
             new Card(new Question("What is a loop"),
                     new Answer("A construct that repeats instructions until a condition is met"),
-                    getTagSet("easy"), Optional.of(defaultDeck)),
+                    getTagSet("easy"), defaultDeck),
             new Card(new Question("What is a variable"),
                     new Answer("A named memory location that stores a value"),
-                    getTagSet("easy"), Optional.of(defaultDeck)),
+                    getTagSet("easy"), defaultDeck),
             new Card(new Question("What is the structure of an atom"),
                     new Answer("Atoms consist of a nucleus containing protons and neutrons, "
                             + "surrounded by electrons in shells or energy levels"),
-                    getTagSet("medium"), Optional.of(defaultDeck)),
+                    getTagSet("medium"), defaultDeck),
             new Card(new Question("What is the basic unit of life"),
                     new Answer("The cell is the basic unit of life"),
-                    getTagSet("easy"), Optional.of(defaultDeck)),
+                    getTagSet("easy"), defaultDeck),
             new Card(new Question("Who was the first president of the United States"),
                     new Answer("George Washington"),
-                    getTagSet("medium"), Optional.of(defaultDeck)),
+                    getTagSet("medium"), defaultDeck),
             new Card(new Question("When did Singapore gain independence"),
                     new Answer("9 August 1965"),
-                    getTagSet("hard"), Optional.of(defaultDeck))
+                    getTagSet("hard"), defaultDeck)
         };
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedCard.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedCard.java
@@ -3,7 +3,6 @@ package seedu.address.storage;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -52,7 +51,7 @@ class JsonAdaptedCard {
         tagged.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
-        deck = source.getDeck().get().deckName;
+        deck = source.getDeck().map(Deck::getDeckName).get();
     }
 
     /**
@@ -85,7 +84,7 @@ class JsonAdaptedCard {
         final Answer modelAnswer = new Answer(answer);
 
         final Set<Tag> modelTags = new HashSet<>(personTags);
-        final Optional<Deck> modelDeck = Optional.of(new Deck(deck));
+        final Deck modelDeck = new Deck(deck); // todo: any constraints on deck name?
         return new Card(modelQuestion, modelAnswer, modelTags, modelDeck);
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -53,6 +53,14 @@ public class AddCommandTest {
     }
 
     @Test
+    public void execute_noSelectedDeck_throwsCommandException() {
+        Card validCard = new CardBuilder().build();
+        AddCommand addCommand = new AddCommand(validCard);
+        ModelStub modelStub = new ModelStubWithoutSelectedDeck();
+        assertThrows(CommandException.class, AddCommand.MESSAGE_NO_SELECTED_DECK, () -> addCommand.execute(modelStub));
+    }
+
+    @Test
     public void equals() {
         Card alice = new CardBuilder().withQuestion("Alice").build();
         Card bob = new CardBuilder().withQuestion("Bob").build();
@@ -77,7 +85,7 @@ public class AddCommandTest {
     }
 
     /**
-     * A default model stub that have all of the methods failing.
+     * A default model stub that have all the methods failing.
      */
     private class ModelStub implements Model {
         @Override
@@ -213,7 +221,6 @@ public class AddCommandTest {
             throw new AssertionError("This method should not be called.");
         }
 
-
         public Optional<Review> getReview() {
             throw new AssertionError("This method should not be called.");
         }
@@ -298,6 +305,22 @@ public class AddCommandTest {
         @Override
         public ReadOnlyMasterDeck getMasterDeck() {
             return new MasterDeck();
+        }
+    }
+
+    /**
+     * A Model stub that does not have any deck selected.
+     */
+    private class ModelStubWithoutSelectedDeck extends ModelStub {
+
+        @Override
+        public boolean hasCard(Card card) {
+            return false;
+        }
+
+        @Override
+        public Optional<Deck> getSelectedDeck() {
+            return Optional.empty();
         }
     }
 

--- a/src/test/java/seedu/address/testutil/CardBuilder.java
+++ b/src/test/java/seedu/address/testutil/CardBuilder.java
@@ -1,7 +1,6 @@
 package seedu.address.testutil;
 
 import java.util.HashSet;
-import java.util.Optional;
 import java.util.Set;
 
 import seedu.address.model.card.Answer;
@@ -23,7 +22,7 @@ public class CardBuilder {
     private Question question;
     private Answer answer;
     private Set<Tag> tags;
-    private Optional<Deck> deck;
+    private Deck deck;
 
 
     /**
@@ -33,7 +32,7 @@ public class CardBuilder {
         question = new Question(DEFAULT_QUESTION);
         answer = new Answer(DEFAULT_ANSWER);
         tags = new HashSet<>();
-        deck = Optional.of(new Deck(DEFAULT_DECK));
+        deck = new Deck(DEFAULT_DECK);
     }
 
     /**
@@ -43,7 +42,7 @@ public class CardBuilder {
         question = cardToCopy.getQuestion();
         answer = cardToCopy.getAnswer();
         tags = new HashSet<>(cardToCopy.getTags());
-        deck = cardToCopy.getDeck();
+        deck = cardToCopy.getDeck().get();
     }
 
     /**
@@ -74,7 +73,7 @@ public class CardBuilder {
      * Sets the {@code Deck} of the {@code Card} that we are building.
      */
     public CardBuilder withDeck(String deckName) {
-        this.deck = Optional.of(new Deck(deckName));
+        this.deck = new Deck(deckName);
         return this;
     }
 


### PR DESCRIPTION
Close https://github.com/AY2223S2-CS2103T-W11-3/tp/issues/109

Future issues:
- Should Deck name be checked for validity? Right now there is no restraint for Deck Name, but in `JsonAdaptedDeck::toModelType()` method, we are checking the deck name as if it it is a Question field.

- Currently in AddCommandParser, a card is initialized with deck as `null`. I propose we make a class called AddCardDescriptor to pass the card arguments to the AddCommand class, where it will be initialized with the selectedDeck. (This approach is similar to the EditCommandParser)