### PR TITLE
Allow non-alphanumeric inputs for question

### DIFF
--- a/src/main/java/seedu/address/model/card/Question.java
+++ b/src/main/java/seedu/address/model/card/Question.java
@@ -9,14 +9,13 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Question {
 
-    public static final String MESSAGE_CONSTRAINTS =
-            "Question should only contain alphanumeric characters and spaces, and it should not be blank";
+    public static final String MESSAGE_CONSTRAINTS = "Question should not be blank";
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "[^\\s].*";
 
     public final String question;
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -37,7 +37,7 @@ public class CommandTestUtil {
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_MEDIUM;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HARD;
 
-    public static final String INVALID_NAME_DESC = " " + PREFIX_QUESTION + "James&"; // '&' not allowed in names
+    public static final String INVALID_NAME_DESC = " " + PREFIX_QUESTION + " "; // '&' not allowed in names
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ANSWER; // empty string not allowed for addresses
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -37,7 +37,7 @@ public class CommandTestUtil {
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_MEDIUM;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HARD;
 
-    public static final String INVALID_NAME_DESC = " " + PREFIX_QUESTION + " "; // '&' not allowed in names
+    public static final String INVALID_NAME_DESC = " " + PREFIX_QUESTION; // empty string not allowed for question
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ANSWER; // empty string not allowed for addresses
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
 

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -69,7 +69,6 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_invalidValue_failure() {
-        assertParseFailure(parser, "1" + INVALID_NAME_DESC, Question.MESSAGE_CONSTRAINTS); // invalid name
         assertParseFailure(parser, "1" + INVALID_ADDRESS_DESC, Answer.MESSAGE_CONSTRAINTS); // invalid address
         assertParseFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS); // invalid tag
 

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -79,7 +79,7 @@ public class EditCommandParserTest {
         assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
 
         // multiple invalid values, but only the first invalid value is captured
-        assertParseFailure(parser, "1" + INVALID_NAME_DESC + VALID_ANSWER_GRAVITY, Question.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + INVALID_NAME_DESC, Question.MESSAGE_CONSTRAINTS);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -19,7 +19,7 @@ import seedu.address.model.card.Question;
 import seedu.address.model.tag.Tag;
 
 public class ParserUtilTest {
-    private static final String INVALID_NAME = "R@chel";
+    private static final String INVALID_NAME = " ";
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_TAG = "#friend";
 

--- a/src/test/java/seedu/address/model/card/AnswerTest.java
+++ b/src/test/java/seedu/address/model/card/AnswerTest.java
@@ -14,7 +14,7 @@ public class AnswerTest {
     }
 
     @Test
-    public void constructor_invalidAddress_throwsIllegalArgumentException() {
+    public void constructor_invalidAnswer_throwsIllegalArgumentException() {
         String invalidAddress = "";
         assertThrows(IllegalArgumentException.class, () -> new Answer(invalidAddress));
     }

--- a/src/test/java/seedu/address/model/card/QuestionTest.java
+++ b/src/test/java/seedu/address/model/card/QuestionTest.java
@@ -14,7 +14,7 @@ public class QuestionTest {
     }
 
     @Test
-    public void constructor_invalidName_throwsIllegalArgumentException() {
+    public void constructor_invalidQuestion_throwsIllegalArgumentException() {
         String invalidName = "";
         assertThrows(IllegalArgumentException.class, () -> new Question(invalidName));
     }
@@ -27,8 +27,6 @@ public class QuestionTest {
         // invalid name
         assertFalse(Question.isValidQuestion("")); // empty string
         assertFalse(Question.isValidQuestion(" ")); // spaces only
-        assertFalse(Question.isValidQuestion("^")); // only non-alphanumeric characters
-        assertFalse(Question.isValidQuestion("peter*")); // contains non-alphanumeric characters
 
         // valid name
         assertTrue(Question.isValidQuestion("peter jack")); // alphabets only

--- a/src/test/java/seedu/address/storage/JsonAdaptedCardTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedCardTest.java
@@ -16,7 +16,7 @@ import seedu.address.model.card.Answer;
 import seedu.address.model.card.Question;
 
 public class JsonAdaptedCardTest {
-    private static final String INVALID_NAME = "R@chel";
+    private static final String INVALID_NAME = " ";
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_TAG = "#friend";
 


### PR DESCRIPTION
(Re-open PR due to multiple mistakes while pushing&pulling) 

Basically same as the previous pr I made but with minor changes for testcases (invalid question).

Can take inputs of numbers, symbols, other language characters for question.

Part of #103 