### PR TITLE
Revamp EditDeckCommand to fix bugs

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditDeckCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditDeckCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DECK_NAME;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_DECKS;
 
 import java.util.List;
@@ -21,11 +22,8 @@ public class EditDeckCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the name of the deck "
             + "by the index number used in the displayed deck list. "
-            + "Existing values will be overwritten by the input values.\n"
-            + "Parameters: INDEX (must be a positive integer) "
-            + "[DECK NAME]...\n"
-            + "Example: " + COMMAND_WORD + " 1 "
-            + "LAC1201";
+            + "Parameters: INDEX (must be a positive integer) " + PREFIX_DECK_NAME + "DECK NAME\n"
+            + "Example: " + COMMAND_WORD + " 1 " + PREFIX_DECK_NAME + "LAC1201";
 
     public static final String MESSAGE_EDIT_DECK_SUCCESS = "Successfully renamed deck to %1$s";
     public static final String MESSAGE_DUPLICATE_DECK = "This deck name already exists.";

--- a/src/main/java/seedu/address/logic/commands/EditDeckCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditDeckCommand.java
@@ -2,7 +2,6 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DECK_NAME;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_DECKS;
 
 import java.util.List;
 
@@ -25,7 +24,7 @@ public class EditDeckCommand extends Command {
             + "Parameters: INDEX (must be a positive integer) " + PREFIX_DECK_NAME + "DECK NAME\n"
             + "Example: " + COMMAND_WORD + " 1 " + PREFIX_DECK_NAME + "LAC1201";
 
-    public static final String MESSAGE_EDIT_DECK_SUCCESS = "Successfully renamed deck to %1$s";
+    public static final String MESSAGE_EDIT_DECK_SUCCESS = "Deck %1$s is successfully renamed to \"%2$s\".";
     public static final String MESSAGE_DUPLICATE_DECK = "This deck name already exists.";
 
     private final Index index;
@@ -46,9 +45,10 @@ public class EditDeckCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Deck> lastShownList = model.getFilteredDeckList();
 
-        if (index.getZeroBased() >= lastShownList.size()) {
+        List<Deck> lastShownList = model.getFilteredDeckList();
+        boolean isIndexOutOfBound = index.getZeroBased() >= lastShownList.size();
+        if (isIndexOutOfBound) {
             throw new CommandException(Messages.MESSAGE_INVALID_DECK_DISPLAYED_INDEX);
         }
 
@@ -57,10 +57,12 @@ public class EditDeckCommand extends Command {
         }
 
         Deck deckToEdit = lastShownList.get(index.getZeroBased());
-        model.setDeck(deckToEdit, editedDeck);
-        model.updateFilteredDeckList(PREDICATE_SHOW_ALL_DECKS);
 
-        return new CommandResult(String.format(MESSAGE_EDIT_DECK_SUCCESS, editedDeck.getDeckName()));
+        model.setDeck(deckToEdit, editedDeck);
+        model.moveCards(deckToEdit, editedDeck);
+
+        return new CommandResult(String.format(MESSAGE_EDIT_DECK_SUCCESS,
+                index.getOneBased(), editedDeck.getDeckName()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -9,5 +9,5 @@ public class CliSyntax {
     public static final Prefix PREFIX_QUESTION = new Prefix("q\\");
     public static final Prefix PREFIX_ANSWER = new Prefix("a\\");
     public static final Prefix PREFIX_TAG = new Prefix("t\\");
-
+    public static final Prefix PREFIX_DECK_NAME = new Prefix("d\\");
 }

--- a/src/main/java/seedu/address/logic/parser/EditDeckCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditDeckCommandParser.java
@@ -2,8 +2,14 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ANSWER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DECK_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_QUESTION;
+
+import java.util.stream.Stream;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.EditDeckCommand;
 import seedu.address.logic.commands.SelectDeckCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -21,20 +27,27 @@ public class EditDeckCommandParser implements Parser<EditDeckCommand> {
      */
     public EditDeckCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_DECK_NAME);
 
         Index index;
-
         try {
-            String i = String.valueOf(args.charAt(1));
-            index = ParserUtil.parseIndex(i);
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    SelectDeckCommand.MESSAGE_USAGE), pe);
+                    EditDeckCommand.MESSAGE_USAGE), pe);
         }
 
-        Deck editedDeck = ParserUtil.parseDeck(args.substring(2));
+        if (!arePrefixesPresent(argMultimap, PREFIX_DECK_NAME)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditDeckCommand.MESSAGE_USAGE));
+        }
+
+        String deckName = argMultimap.getValue(PREFIX_DECK_NAME).get();
+        Deck editedDeck = ParserUtil.parseDeck(deckName);
 
         return new EditDeckCommand(index, editedDeck);
+    }
+
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/main/java/seedu/address/logic/parser/EditDeckCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditDeckCommandParser.java
@@ -2,16 +2,12 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ANSWER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DECK_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_QUESTION;
 
 import java.util.stream.Stream;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.EditDeckCommand;
-import seedu.address.logic.commands.SelectDeckCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.deck.Deck;
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -92,13 +92,13 @@ public class ParserUtil {
     }
 
     /**
-     * Parses {@code Collection<String> decks} into a {@code Set<Deck>}
+     * Parses {@code String deckName} into a {@code Deck}
      */
     public static Deck parseDeck(String deckName) throws ParseException {
         requireNonNull(deckName);
         String trimmedDeckName = deckName.trim();
-        if (!Answer.isValidAnswer(trimmedDeckName)) {
-            throw new ParseException(Answer.MESSAGE_CONSTRAINTS);
+        if (!Deck.isValidDeckName(trimmedDeckName)) {
+            throw new ParseException(Deck.MESSAGE_CONSTRAINTS);
         }
         return new Deck(trimmedDeckName);
     }

--- a/src/main/java/seedu/address/model/MasterDeck.java
+++ b/src/main/java/seedu/address/model/MasterDeck.java
@@ -146,6 +146,21 @@ public class MasterDeck implements ReadOnlyMasterDeck {
     }
 
     /**
+     * Changes the association of all the cards from the old deck to the new deck.
+     *
+     * @param oldDeck The deck which cards are currently associated with.
+     * @param newDeck The deck which cards are to be associated with.
+     */
+    public void moveCards(Deck oldDeck, Deck newDeck) {
+        for (Card c : cards) {
+            if (c.isInDeck(oldDeck)) {
+                Card editedCard = new Card(c.getQuestion(), c.getAnswer(), c.getTags(), newDeck);
+                setCard(c, editedCard);
+            }
+        }
+    }
+
+    /**
      * Removes {@code key} from this {@code MasterDeck} and its corresponding cards.
      * {@code key} must exist.
      */

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -96,6 +96,7 @@ public interface Model {
 
 
     /* NEWLY ADDED COMMANDS TO SUPPORT DECK LIST (NOT IN AB3) */
+
     void updateFilteredDeckList(Predicate<Deck> predicate);
 
     /** Returns the deck */
@@ -107,12 +108,21 @@ public interface Model {
      * Returns true if a deck with the same name as {@code deck} exists.
      */
     boolean hasDeck(Deck deck);
+
     /**
      * Replaces the given deck {@code target} with {@code editedDeck}.
      * {@code target} must exist.
      * The deck name of {@code editedDeck} must not be the same as another existing deck.
      */
     void setDeck(Deck target, Deck editedDeck);
+
+    /**
+     * Changes the association of all the cards from the old deck to the new deck.
+     *
+     * @param oldDeck The deck which cards are currently associated with.
+     * @param newDeck The deck which cards are to be associated with.
+     */
+    void moveCards(Deck oldDeck, Deck newDeck);
 
     void deleteDeck(Deck key);
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -186,6 +186,11 @@ public class ModelManager implements Model {
         masterDeck.setDeck(target, editedDeck);
     }
 
+    @Override
+    public void moveCards(Deck oldDeck, Deck newDeck) {
+        masterDeck.moveCards(oldDeck, newDeck);
+    }
+
     /**
      * Deletes the given deck and the associated cards in that deck.
      *

--- a/src/main/java/seedu/address/model/deck/Deck.java
+++ b/src/main/java/seedu/address/model/deck/Deck.java
@@ -11,6 +11,10 @@ public class Deck {
 
     public final String deckName;
 
+    public static final String MESSAGE_CONSTRAINTS = "Deck name can take any values, and it should not be blank";
+    public static final String VALIDATION_REGEX = "[^\\s].*";
+
+
     /**
      * Constructing a deck.
      * Every field must be present and not null.
@@ -26,6 +30,13 @@ public class Deck {
      */
     public String getDeckName() {
         return this.deckName;
+    }
+
+    /**
+     * Returns true if a given string is a valid deck name.
+     */
+    public static boolean isValidDeckName(String deckName) {
+        return deckName.matches(VALIDATION_REGEX);
     }
 
     /**

--- a/src/main/java/seedu/address/model/deck/Deck.java
+++ b/src/main/java/seedu/address/model/deck/Deck.java
@@ -8,12 +8,9 @@ import java.util.Objects;
  * A group of cards
  */
 public class Deck {
-
-    public final String deckName;
-
     public static final String MESSAGE_CONSTRAINTS = "Deck name can take any values, and it should not be blank";
     public static final String VALIDATION_REGEX = "[^\\s].*";
-
+    public final String deckName;
 
     /**
      * Constructing a deck.

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -189,6 +189,11 @@ public class AddCommandTest {
             throw new AssertionError("This method should not be called.");
         }
 
+        public void moveCards(Deck oldDeck, Deck newDeck) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+
         @Override
         public void deleteDeck(Deck key) {
             throw new AssertionError("This method should not be called.");

--- a/src/test/java/seedu/address/logic/commands/AddDeckCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddDeckCommandTest.java
@@ -183,6 +183,11 @@ public class AddDeckCommandTest {
         }
 
         @Override
+        public void moveCards(Deck target, Deck editedDeck) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void deleteDeck(Deck key) {
             throw new AssertionError("This method should not be called.");
         }
@@ -206,7 +211,6 @@ public class AddDeckCommandTest {
         public int getDeckSize(int deckIndex) {
             throw new AssertionError("This method should not be called.");
         }
-
 
         public Optional<Review> getReview() {
             throw new AssertionError("This method should not be called.");

--- a/src/test/java/seedu/address/logic/commands/EditDeckCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditDeckCommandTest.java
@@ -23,7 +23,7 @@ import seedu.address.model.deck.Deck;
  */
 public class EditDeckCommandTest {
 
-    private Model model = new ModelManager(getTypicalMasterDeck(), new UserPrefs());
+    private final Model model = new ModelManager(getTypicalMasterDeck(), new UserPrefs());
 
     @Test
     public void execute_editDeck_editSuccessful() {
@@ -31,10 +31,13 @@ public class EditDeckCommandTest {
 
         EditDeckCommand editDeckCommand = new EditDeckCommand(INDEX_FIRST, editedDeck);
 
-        String expectedMessage = String.format(EditDeckCommand.MESSAGE_EDIT_DECK_SUCCESS, editedDeck);
+        String expectedMessage = String.format(EditDeckCommand.MESSAGE_EDIT_DECK_SUCCESS,
+                INDEX_FIRST.getOneBased(), editedDeck);
 
-        Model expectedModel = new ModelManager(new MasterDeck(model.getMasterDeck()), new UserPrefs());
+        Model expectedModel = new ModelManager(model.getMasterDeck(), new UserPrefs());
         expectedModel.setDeck(model.getFilteredDeckList().get(0), editedDeck);
+        expectedModel.moveCards(model.getFilteredDeckList().get(0), editedDeck);
+
         assertCommandSuccess(editDeckCommand, model, expectedMessage, expectedModel);
     }
 

--- a/src/test/java/seedu/address/logic/commands/EditDeckCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditDeckCommandTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
-import seedu.address.model.MasterDeck;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;


### PR DESCRIPTION
Fix these 2 bugs:
- [x] Calling `editDeck 10 NEW DECK NAME` will result in deck 1 being renamed to `0 NEW DECK NAME` → Solution: Use the given Tokenizer. The new command for editDeck is `editDeck 10 d\NEW DECK NAME`
- [x] Renaming a deck will not change the associations in the cards to the new deck.