### PR TITLE
Fix for can't flip after tagging

### DIFF
--- a/src/main/java/seedu/address/model/MasterDeck.java
+++ b/src/main/java/seedu/address/model/MasterDeck.java
@@ -101,6 +101,10 @@ public class MasterDeck implements ReadOnlyMasterDeck {
         cards.tagCard(target, tag);
     }
 
+    public void flipCard(Card target) {
+        cards.flipCard(target);
+    }
+
     /**
      * Removes {@code key} from this {@code Deck}.
      * {@code key} must exist in the MasterDeck.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -325,8 +325,9 @@ public class ModelManager implements Model {
     @Override
     public void flipCard() {
         assert currReview != null : "Flip command executed without a Review session.";
-        currReview.flipCard();
-        updateFilteredCardList(new IsSameCardPredicate(currReview.getCurrCard()));
+        masterDeck.flipCard(filteredCards.get(0));
+        //        currReview.flipCard();
+        //        updateFilteredCardList(new IsSameCardPredicate(currReview.getCurrCard()));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/card/UniqueCardList.java
+++ b/src/main/java/seedu/address/model/card/UniqueCardList.java
@@ -83,6 +83,20 @@ public class UniqueCardList implements Iterable<Card> {
     }
 
     /**
+     * Replaces old card with new card that is flipped.
+     * @param target
+     */
+    public void flipCard(Card target) {
+        int index = internalList.indexOf(target);
+        if (target.isFlipped()) {
+            target.setAsUnflipped();
+        } else {
+            target.setAsFlipped();
+        }
+        internalList.set(index, target);
+    }
+
+    /**
      * Removes the equivalent card from the list.
      * The card must exist in the list.
      */


### PR DESCRIPTION
This fixes the issue if I am not mistaken (at least temporarily) because flip is not a mutable attribute and not considered when doing `isSameCard` for PR #206 

Same fix as the old PR where tagging doesn't update dynamically.


https://user-images.githubusercontent.com/85063215/227778124-ea1633e2-bca1-4281-90a2-99b392015e65.mov


