### PR TITLE
[Bug] Fix bug where limit is not the same in the Easy/Medium/Hard statistics

### DIFF
--- a/src/main/java/seedu/address/model/review/Review.java
+++ b/src/main/java/seedu/address/model/review/Review.java
@@ -46,6 +46,7 @@ public class Review {
                 ? cardsInDeck.size()
                 : Integer.min(userSetNum, cardsInDeck.size());
 
+        // Initialize the unique card list
         initReviewCardList(cardsInDeck);
         this.unmodifiableReviewCardList = uniqueReviewCardList.asUnmodifiableObservableList();
         filteredReviewCardList = new FilteredList<>(this.unmodifiableReviewCardList);
@@ -64,7 +65,7 @@ public class Review {
     }
 
     /**
-     * Initialize all cards as unflipped.
+     * Initialize all cards as unflipped in an UniqueCardList instance.
      *
      * @param cardList List of Cards to initialize UniqueCardList with.
      */
@@ -192,15 +193,21 @@ public class Review {
     }
 
     public int getNoOfEasyTags() {
-        return (int) unmodifiableReviewCardList.stream().filter(card -> card.getTagName().equals("easy")).count();
+        return (int) unmodifiableReviewCardList.stream()
+                .filter(card -> orderOfCards.contains(unmodifiableReviewCardList.indexOf(card)))
+                .filter(card -> card.getTagName().equals("easy")).count();
     }
 
     public int getNoOfMediumTags() {
-        return (int) unmodifiableReviewCardList.stream().filter(card -> card.getTagName().equals("medium")).count();
+        return (int) unmodifiableReviewCardList.stream()
+                .filter(card -> orderOfCards.contains(unmodifiableReviewCardList.indexOf(card)))
+                .filter(card -> card.getTagName().equals("medium")).count();
     }
 
     public int getNoOfHardTags() {
-        return (int) unmodifiableReviewCardList.stream().filter(card -> card.getTagName().equals("hard")).count();
+        return (int) unmodifiableReviewCardList.stream()
+                .filter(card -> orderOfCards.contains(unmodifiableReviewCardList.indexOf(card)))
+                .filter(card -> card.getTagName().equals("hard")).count();
     }
 
     public int getNoOfUntagged() {

--- a/src/main/java/seedu/address/model/review/Review.java
+++ b/src/main/java/seedu/address/model/review/Review.java
@@ -56,7 +56,7 @@ public class Review {
                 .distinct().limit(totalNumCards).boxed().collect(Collectors.toList());
 
         // initialise first card
-        currCard = this.uniqueReviewCardList.asUnmodifiableObservableList().get(orderOfCards.get(currCardIndex));
+        currCard = this.unmodifiableReviewCardList.get(orderOfCards.get(currCardIndex));
         filteredReviewCardList.setPredicate(new IsSameCardPredicate(currCard));
 
         // initialize review stats

--- a/src/main/java/seedu/address/model/review/Review.java
+++ b/src/main/java/seedu/address/model/review/Review.java
@@ -193,20 +193,21 @@ public class Review {
     }
 
     public int getNoOfEasyTags() {
-        return (int) unmodifiableReviewCardList.stream()
-                .filter(card -> orderOfCards.contains(unmodifiableReviewCardList.indexOf(card)))
+        return (int) orderOfCards.stream()
+                .map(unmodifiableReviewCardList::get)
                 .filter(card -> card.getTagName().equals("easy")).count();
+
     }
 
     public int getNoOfMediumTags() {
-        return (int) unmodifiableReviewCardList.stream()
-                .filter(card -> orderOfCards.contains(unmodifiableReviewCardList.indexOf(card)))
+        return (int) orderOfCards.stream()
+                .map(unmodifiableReviewCardList::get)
                 .filter(card -> card.getTagName().equals("medium")).count();
     }
 
     public int getNoOfHardTags() {
-        return (int) unmodifiableReviewCardList.stream()
-                .filter(card -> orderOfCards.contains(unmodifiableReviewCardList.indexOf(card)))
+        return (int) orderOfCards.stream()
+                .map(unmodifiableReviewCardList::get)
                 .filter(card -> card.getTagName().equals("hard")).count();
     }
 


### PR DESCRIPTION
- The total number of Easy/Review/Hard cards in Review Statistic is now equal to the number of card set in limit.

close #238 