### PR TITLE
Fix bugs related to card and review

### DIFF
--- a/src/main/java/seedu/address/logic/commands/cardcommands/AddCardCommand.java
+++ b/src/main/java/seedu/address/logic/commands/cardcommands/AddCardCommand.java
@@ -35,7 +35,8 @@ public class AddCardCommand extends Command {
             + PREFIX_TAG + "hard";
 
     public static final String MESSAGE_SUCCESS = "New card added: %1$s";
-    public static final String MESSAGE_DUPLICATE_CARD = "This card already exists in this selected deck.";
+    public static final String MESSAGE_DUPLICATE_CARD = "A card with the same question "
+            + "already exists in this selected deck.";
     public static final String MESSAGE_NO_SELECTED_DECK = "A deck must be selected before a card can be added";
     private final AddCardDescriptor cardDescriptor;
 

--- a/src/main/java/seedu/address/logic/commands/cardcommands/EditCardCommand.java
+++ b/src/main/java/seedu/address/logic/commands/cardcommands/EditCardCommand.java
@@ -42,7 +42,8 @@ public class EditCardCommand extends Command {
 
     public static final String MESSAGE_EDIT_CARD_SUCCESS = "Edited Card: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_CARD = "This card already exists in the master deck.";
+    public static final String MESSAGE_DUPLICATE_CARD = "A card with the same question "
+            + "already exists in this selected deck.";
 
     private final Index index;
     private final EditCardDescriptor editCardDescriptor;

--- a/src/main/java/seedu/address/logic/commands/deckcommands/AddDeckCommand.java
+++ b/src/main/java/seedu/address/logic/commands/deckcommands/AddDeckCommand.java
@@ -22,7 +22,7 @@ public class AddDeckCommand extends Command {
             + "LAK1201";
 
     public static final String MESSAGE_SUCCESS = "New deck created: %1$s";
-    public static final String MESSAGE_DUPLICATE_DECK = "This deck already exists in the deck list";
+    public static final String MESSAGE_DUPLICATE_DECK = "This deck name already exists.";
 
     private final Deck toAdd;
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -292,6 +292,7 @@ public class ModelManager implements Model {
     @Override
     public void endReview() {
         currReview = null;
+        updateFilteredDeckList(PREDICATE_SHOW_ALL_DECKS);
         if (selectedDeck != null) {
             updateFilteredCardList(new CardInDeckPredicate(selectedDeck));
         } else {

--- a/src/main/java/seedu/address/model/card/Card.java
+++ b/src/main/java/seedu/address/model/card/Card.java
@@ -102,7 +102,6 @@ public class Card {
 
         return otherCard != null
                 && otherCard.getQuestion().equals(getQuestion())
-                && otherCard.getAnswer().equals(getAnswer())
                 && otherCard.getDeck().equals(getDeck());
     }
 

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -18,7 +18,7 @@ public class Tag {
         HARD
     }
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be either Easy, Medium, or Hard. "
+    public static final String MESSAGE_CONSTRAINTS = "Tags names should be either 'Easy', 'Medium', or 'Hard'. "
             + "Tag is case-insensitive.";
 
     public static final String VALIDATION_REGEX = "(?i)\\b(easy|medium|hard)\\b";

--- a/src/test/java/seedu/address/model/card/CardTest.java
+++ b/src/test/java/seedu/address/model/card/CardTest.java
@@ -62,19 +62,14 @@ public class CardTest {
         editedLoop = new CardBuilder(LOOP).withQuestion(VALID_QUESTION_PHOTOSYNTHESIS).build();
         assertFalse(LOOP.isSameCard(editedLoop));
 
-        // different answer, all other attributes same -> returns false
+        // different answer, all other attributes same -> returns true
         editedLoop = new CardBuilder(LOOP).withAnswer(VALID_ANSWER_PHOTOSYNTHESIS).build();
-        assertFalse(LOOP.isSameCard(editedLoop));
+        assertTrue(LOOP.isSameCard(editedLoop));
 
         // question differs in case, all other attributes same -> returns false
         Card editedPhotosynthesis = new CardBuilder(PHOTOSYNTHESIS)
                 .withQuestion(VALID_QUESTION_PHOTOSYNTHESIS.toLowerCase())
                 .build();
-        assertFalse(PHOTOSYNTHESIS.isSameCard(editedPhotosynthesis));
-
-        // question has trailing spaces, all other attributes same -> returns false
-        String questionWithTrailingSpaces = VALID_QUESTION_PHOTOSYNTHESIS + " ";
-        editedPhotosynthesis = new CardBuilder(PHOTOSYNTHESIS).withQuestion(questionWithTrailingSpaces).build();
         assertFalse(PHOTOSYNTHESIS.isSameCard(editedPhotosynthesis));
     }
 


### PR DESCRIPTION
Update such that when a review is ended, all filters for deck and card is removed.
closes #363 

Update such that a card is defined by just the question and the deck (not the answer)
closes #315 